### PR TITLE
Add "visit_code" to appointment displays

### DIFF
--- a/flourish_calendar/templates/flourish_calendar/appointment_template.html
+++ b/flourish_calendar/templates/flourish_calendar/appointment_template.html
@@ -38,9 +38,9 @@
         {% endfor %}">
 
         {% if status_color %}
-            {{ subject_identifier }}
+            {{ subject_identifier }} : {{ visit_code }}
         {% else %}
-            <span style="color: black">{{ subject_identifier }}</span>
+            <span style="color: black">{{ subject_identifier }} : {{ visit_code }}</span>
         {% endif %}
         {{ icon }}
     </button>


### PR DESCRIPTION
The appointment template was updated to include both the "subject_identifier" and "visit_code" within the appointment slots. Adding visit_code provides users an immediate understanding of the appointment's purpose, enhancing clarity and efficiency for users.