### PR TITLE
refactor(Export): Refactor child age calculation and modify CSV headers

### DIFF
--- a/flourish_calendar/utils/export_helper.py
+++ b/flourish_calendar/utils/export_helper.py
@@ -59,8 +59,11 @@ def current_cohort(subject_identifier):
 
 
 def get_child_age(subject_identifier=None):
-    _current_cohort = current_cohort(subject_identifier)
-    if _current_cohort:
+    try:
+        _current_cohort = cohort_objs(subject_identifier).latest('assign_datetime')
+    except ObjectDoesNotExist:
+        return None
+    else:
         caregiver_child_consent_obj = _current_cohort.caregiver_child_consent
         if caregiver_child_consent_obj:
             child_age = age(caregiver_child_consent_obj.child_dob, get_utcnow())

--- a/flourish_calendar/views.py
+++ b/flourish_calendar/views.py
@@ -151,7 +151,7 @@ def export_events_as_csv(request):
                 'current_cohort': current_cohort_name,
                 'enrolment_cohort': enrolment_cohort_name,
                 'title': f'{event.title}',
-                'description': f'{event.title}',
+                'description': f'{event.description}',
                 'exposure_status': exposure_status,
             })
 

--- a/flourish_calendar/views.py
+++ b/flourish_calendar/views.py
@@ -103,7 +103,8 @@ class CalendarView(NavbarViewMixin, EdcBaseViewMixin, generic.ListView):
 
 def export_events_as_csv(request):
     csv_headers = ['Event Type', 'Event Date', 'Subject Identifier', 'Child Age',
-                   'Current Cohort', 'Enrolment Cohort', 'Exposure Status', 'Details']
+                   'Current Cohort', 'Enrolment Cohort', 'Exposure Status', 'Title',
+                   'Description']
 
     # Generate datetime stamp for file name
     timestamp_str = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
@@ -134,8 +135,9 @@ def export_events_as_csv(request):
                 'event_type': 'Appointment',
                 'date': event.appt_datetime.date(),
                 'subject_identifier': event.subject_identifier,
-                'description': f'Appointment: {event.visit_code}',
+                'title': f'Appointment: {event.visit_code}',
                 'child_age': get_child_age(event.subject_identifier),
+                'description': '',
                 'current_cohort': current_cohort_name,
                 'enrolment_cohort': enrolment_cohort_name,
                 'exposure_status': exposure_status,
@@ -148,6 +150,7 @@ def export_events_as_csv(request):
                 'child_age': get_child_age(event.subject_identifier),
                 'current_cohort': current_cohort_name,
                 'enrolment_cohort': enrolment_cohort_name,
+                'title': f'{event.title}',
                 'description': f'{event.title}',
                 'exposure_status': exposure_status,
             })
@@ -157,6 +160,6 @@ def export_events_as_csv(request):
             [obj.get('event_type'), obj.get('date'), obj.get('subject_identifier'),
              obj.get('child_age'), obj.get('current_cohort'),
              obj.get('enrolment_cohort'), obj.get('exposure_status'),
-             obj.get('description')])
+             obj.get('title'), obj.get('description')])
 
     return response


### PR DESCRIPTION
The method for calculating the child's age in the Flourish Calendar has been refactored to handle exceptions when there is no current cohort info for the subject. In addition, headers and fields for the CSV export have been updated: 'Title' and 'Description' fields were added to enhance data clarity.